### PR TITLE
Disable default docker log rotation

### DIFF
--- a/pkg/generator/templates/cloud-init/suse-jeos.template
+++ b/pkg/generator/templates/cloud-init/suse-jeos.template
@@ -1,5 +1,12 @@
 #cloud-config
 write_files:
+{{ if .Bootstrap -}}
+- path: '/etc/docker/daemon.json'
+  permissions: '0644'
+  encoding: b64
+  content: |
+    ewogICJsb2ctbGV2ZWwiOiAid2FybiIsCiAgImxvZy1kcml2ZXIiOiAianNvbi1maWxlIgp9Cg==
+{{ end -}}
 {{ range $_, $file := .Files -}}
 - path: '{{ $file.Path }}'
 {{- if $file.Permissions }}

--- a/pkg/generator/templates/script/suse-jeos.template
+++ b/pkg/generator/templates/script/suse-jeos.template
@@ -5,6 +5,16 @@ cat << EOF | base64 -d > '{{ .Path }}'
 EOF
 {{- end }}
 
+{{ if .Bootstrap -}}
+# disable the default log rotation
+cat <<EOF > /etc/docker/daemon.json
+{
+  "log-level": "warn",
+  "log-driver": "json-file"
+}
+EOF
+{{ end -}}
+
 {{ range $_, $file := .Files -}}
 mkdir -p '{{ $file.Dirname }}'
 {{ template "put-content" $file }}

--- a/pkg/generator/testfiles/cloud-init/cloud-init
+++ b/pkg/generator/testfiles/cloud-init/cloud-init
@@ -1,5 +1,10 @@
 #cloud-config
 write_files:
+- path: '/etc/docker/daemon.json'
+  permissions: '0644'
+  encoding: b64
+  content: |
+    ewogICJsb2ctbGV2ZWwiOiAid2FybiIsCiAgImxvZy1kcml2ZXIiOiAianNvbi1maWxlIgp9Cg==
 - path: '/foo'
   permissions: '0600'
   encoding: b64

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# disable the default log rotation
+cat <<EOF > /etc/docker/daemon.json
+{
+  "log-level": "warn",
+  "log-driver": "json-file"
+}
+EOF
 mkdir -p '/'
 cat << EOF | base64 -d > '/foo'
 YmFy


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable default docker log rotation.

**Which issue(s) this PR fixes**:
Fixes #6 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The default docker daemon log rotation is now disabled for newly created nodes.
```
