### PR TITLE
Make the DHCP client aware of MTU changes

### DIFF
--- a/pkg/generator/templates/cloud-init/suse-jeos.template
+++ b/pkg/generator/templates/cloud-init/suse-jeos.template
@@ -37,6 +37,7 @@ runcmd:
 - systemctl daemon-reload
 - ip link set dev eth0 mtu 1460
 - grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
+- wicked ifreload eth0
 {{ if .Bootstrap -}}
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip

--- a/pkg/generator/templates/script/suse-jeos.template
+++ b/pkg/generator/templates/script/suse-jeos.template
@@ -38,6 +38,7 @@ until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sle
 systemctl daemon-reload
 ip link set dev eth0 mtu 1460
 grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
+wicked ifreload eth0
 {{ if .Bootstrap -}}
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip

--- a/pkg/generator/testfiles/cloud-init/cloud-init
+++ b/pkg/generator/testfiles/cloud-init/cloud-init
@@ -23,6 +23,7 @@ runcmd:
 - systemctl daemon-reload
 - ip link set dev eth0 mtu 1460
 - grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
+- wicked ifreload eth0
 - ln -s /usr/bin/docker /bin/docker
 - ln -s /bin/ip /usr/bin/ip
 - if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi

--- a/pkg/generator/testfiles/script/cloud-init
+++ b/pkg/generator/testfiles/script/cloud-init
@@ -26,6 +26,7 @@ until zypper -q install -y docker wget socat jq nfs-client; [ $? -ne 7 ]; do sle
 systemctl daemon-reload
 ip link set dev eth0 mtu 1460
 grep -q '^MTU' /etc/sysconfig/network/ifcfg-eth0 && sed -i 's/^MTU.*/MTU=1460/' /etc/sysconfig/network/ifcfg-eth0 || echo 'MTU=1460' >> /etc/sysconfig/network/ifcfg-eth0
+wicked ifreload eth0
 ln -s /usr/bin/docker /bin/docker
 ln -s /bin/ip /usr/bin/ip
 if [ ! -s /etc/hostname ]; then hostname > /etc/hostname; fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the DHCP client aware of MTU changes


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The dhcp client `wicked` is now aware of the MTU customization and it will not revert the MTU settings.
```
